### PR TITLE
Add option UseCurrentFolderAsPlaylistName to generate playlist name automaticly

### DIFF
--- a/CommandLineArguments.cs
+++ b/CommandLineArguments.cs
@@ -1,10 +1,6 @@
 ﻿using CommandLine;
 using CommandLine.Text;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PlayListGenerator
 {
@@ -26,7 +22,7 @@ namespace PlayListGenerator
 
         [Value(0, HelpText = "[drive:][path][filename_or_mask]", Required = true)]
         public string PathAndMask { get; set; }
-        [Value(1, HelpText = "[filename]", Required = true)]
+        [Value(1, HelpText = "[filename]", Required = false)]
         public string PlayListFilename { get; set; }
         [Option('S', "SubDirectories", HelpText = "Include subdirectories (recursive)")]
         public bool Recursive { get; set; }
@@ -37,6 +33,9 @@ namespace PlayListGenerator
 
         [Option('O', "OnePlaylistByFolder", HelpText = "Create 1 playlist by folder of the current folder")]
         public bool OnePlaylistByFolder { get; set; }
+
+        [Option('U', "UseCurrentFolderAsPlaylistName", HelpText = "If OnePlaylistByFolder(O) and SubDirectories(S) options selected, then combine this option to use the current folder as PlayListFilename. Usefull to avoid using the same PlayListFilename for all playlist generated")]
+        public bool UseCurrentFolderAsPlaylistName { get; set; }
 
         [Usage()]
         public static IEnumerable<Example> Examples

--- a/GeneratePlaylistBase.cs
+++ b/GeneratePlaylistBase.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace PlayListGenerator
 {
@@ -12,6 +9,16 @@ namespace PlayListGenerator
     /// </summary>
     internal abstract class GeneratePlaylistBase
     {
+        
+        /// <summary>
+        /// Return the file extension for the playlist.
+        /// </summary>
+        /// <returns></returns>
+        public abstract string FileExtension
+        {
+            get;
+        }
+        
         /// <summary>
         /// Method that will be called to generate the playlist file
         /// </summary>
@@ -33,7 +40,7 @@ namespace PlayListGenerator
             fileContent.Append(GetFooter());
 
             // Generate the playlist file
-            File.WriteAllText(aPlayListFileName, fileContent.ToString());
+            File.WriteAllText(aPlayListFileName, fileContent.ToString(), Encoding.UTF8);
         }
 
         /// <summary>

--- a/Generate_m3u.cs
+++ b/Generate_m3u.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PlayListGenerator
 {
@@ -12,6 +8,14 @@ namespace PlayListGenerator
     class Generate_m3u : GeneratePlaylistBase
     {
 
+        public override string FileExtension
+        {
+            get
+            {
+                return "m3u";
+            }
+        }
+        
         protected override string GetHeader()
         {
             return "#EXTM3U"+Environment.NewLine;

--- a/Generate_xspf.cs
+++ b/Generate_xspf.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PlayListGenerator
 {
@@ -11,6 +7,13 @@ namespace PlayListGenerator
     /// </summary>
     internal class Generate_xspf : GeneratePlaylistBase
     {
+        public override string FileExtension
+        {
+            get
+            {
+                return "xspf";
+            }
+        }
 
         protected override string GetHeader()
         {

--- a/PathHelper.cs
+++ b/PathHelper.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace PlayListGenerator
 {

--- a/Program.cs
+++ b/Program.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using CommandLine;
-using System.Diagnostics;
+﻿using CommandLine;
 using CommandLine.Text;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace PlayListGenerator
 {
@@ -83,7 +80,8 @@ namespace PlayListGenerator
         /// </summary>
         /// <param name="args"></param>
         private static void Run(CommandLineArguments args)
-        {
+        {          
+
             // Create the file generator
             GeneratePlaylistBase playlistGenerator;
             switch (args.Format)
@@ -97,6 +95,8 @@ namespace PlayListGenerator
                 default:
                     throw new Exception("Unkown playlist format");
             }
+
+            args.PlayListFilename = string.IsNullOrEmpty(args.PlayListFilename) ? $"default.{playlistGenerator.FileExtension}" : args.PlayListFilename; 
 
             // Separate directory and file mask
             var dirAndMask = PathHelper.ExtractDirectoryandMask(args.PathAndMask);
@@ -120,6 +120,12 @@ namespace PlayListGenerator
                 List<string> directories = new List<string>(Directory.EnumerateDirectories(directory));
                 foreach (var dir in directories)
                 {
+
+                    if (args.UseCurrentFolderAsPlaylistName)
+                    {
+                        args.PlayListFilename = Path.Combine(dir, $"{dir.Split(Path.DirectorySeparatorChar).Last()}.{playlistGenerator.FileExtension}");
+                    }
+                    
                     // Generate playlist of the folder
                     Run(playlistGenerator, dir, mask, Path.Combine(dir, args.PlayListFilename), args.RelativePath, args.Recursive);
                 }


### PR DESCRIPTION
If OnePlaylistByFolder(O) and SubDirectories(S) options selected, then
combine this option to use the current folder as PlayListFilename. Usefull to avoid using the same PlayListFilename for all playlist generated. Also Enforce UTF8 encoding.